### PR TITLE
add darwin.arm64 builds, simplify makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,8 @@ VERSION=$(shell cat VERSION)
 BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_HASH=$(shell git rev-parse HEAD)
 
-BINARIES=bin/mtr-exporter-$(VERSION).linux.amd64 \
-		 bin/mtr-exporter-$(VERSION).linux.386 \
-		 bin/mtr-exporter-$(VERSION).linux.arm64 \
-		 bin/mtr-exporter-$(VERSION).linux.mips64 \
-		 bin/mtr-exporter-$(VERSION).windows.amd64.exe \
-		 bin/mtr-exporter-$(VERSION).freebsd.amd64 \
-		 bin/mtr-exporter-$(VERSION).darwin.amd64
+BUILDS=linux.amd64 linux.386 linux.arm64 linux.mips64 windows.amd64.exe freebsd.amd64 darwin.amd64 darwin.arm64
+BINARIES=$(addprefix bin/mtr-exporter-$(VERSION)., $(BUILDS))
 
 LDFLAGS=-ldflags "-X main.Version=$(VERSION) -X main.BuildDate=$(BUILD_DATE) -X main.GitHash=$(GIT_HASH)"
 
@@ -36,26 +31,17 @@ container-image:
 		--build-arg MTR_BIN=bin/mtr-exporter-$(VERSION).linux.amd64 \
 		--tag mtr-exporter:$(VERSION) .
 
-bin/mtr-exporter-$(VERSION).linux.mips64: bin
-	cd cmd/mtr-exporter && env GOOS=linux GOARCH=mips64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
+bin/mtr-exporter-$(VERSION).linux.%: bin
+	cd cmd/mtr-exporter && env GOOS=linux GOARCH=$* CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
 
-bin/mtr-exporter-$(VERSION).linux.amd64: bin
-	cd cmd/mtr-exporter && env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
+bin/mtr-exporter-$(VERSION).darwin.%: bin
+	cd cmd/mtr-exporter && env GOOS=darwin GOARCH=$* CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
 
-bin/mtr-exporter-$(VERSION).linux.386: bin
-	cd cmd/mtr-exporter && env GOOS=linux GOARCH=386 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
+bin/mtr-exporter-$(VERSION).windows.%.exe: bin
+	cd cmd/mtr-exporter && env GOOS=windows GOARCH=$* CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
 
-bin/mtr-exporter-$(VERSION).linux.arm64: bin
-	cd cmd/mtr-exporter && env GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
-
-bin/mtr-exporter-$(VERSION).windows.amd64.exe: bin
-	cd cmd/mtr-exporter && env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
-
-bin/mtr-exporter-$(VERSION).darwin.amd64: bin
-	cd cmd/mtr-exporter && env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
-
-bin/mtr-exporter-$(VERSION).freebsd.amd64: bin
-	cd cmd/mtr-exporter && env GOOS=freebsd GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
+bin/mtr-exporter-$(VERSION).freebsd.%: bin
+	cd cmd/mtr-exporter && env GOOS=freebsd GOARCH=$* CGO_ENABLED=0 go build $(LDFLAGS) -o ../../$@
 
 bin:
 	mkdir $@


### PR DESCRIPTION
M1 Macs are more and more prevalent and it would be nice to have a release with binary for Darwin ARM64.

Also removed some repetition by using [Makefile pattern rules](https://www.gnu.org/software/make/manual/html_node/Pattern-Rules.html) and `addprefix` method to generate filenames of targets.