### PR TITLE
add /health route that returns 200 and OK

### DIFF
--- a/cmd/mtr-exporter/main.go
+++ b/cmd/mtr-exporter/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -59,6 +60,9 @@ func main() {
 	c.Start()
 
 	http.Handle("/metrics", job)
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
 
 	log.Println("serving /metrics at", *bind, "...")
 	log.Fatal(http.ListenAndServe(*bind, nil))


### PR DESCRIPTION
Useful for monitoring the service without hitting `/metrics` and generating unnecessary CPU utilization.

I monitor my services with Consul, so this is the cheapest way to check if it's healthy.