### PR TITLE
Add github workflow to publish oci image as github artefact

### DIFF
--- a/.github/workflows/docker-publish-tags.yml
+++ b/.github/workflows/docker-publish-tags.yml
@@ -19,20 +19,27 @@ jobs:
 
     steps:
       - name: Checkout and download repository to workflow runner
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to github container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+
       - name: Build and push image to github container registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Containerfile
@@ -40,4 +47,5 @@ jobs:
           platforms: "linux/amd64"
           build-args: |
              VERSION=${{github.ref_name}}
-          tags:  "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{github.ref_name}}"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish-tags.yml
+++ b/.github/workflows/docker-publish-tags.yml
@@ -1,0 +1,43 @@
+name: Build on tags
+
+on:
+  push:
+    tags: [ '*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    #--- Set permissions to ephemeral GITHUB_TOKEN for job actions
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout and download repository to workflow runner
+        uses: actions/checkout@v3
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to github container registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Containerfile
+          push: true
+          platforms: "linux/amd64"
+          build-args: |
+             VERSION=${{github.ref_name}}
+          tags:  "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{github.ref_name}}"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ One-off building and "installation":
 
     $> go install github.com/mgumz/mtr-exporter/cmd/mtr-exporter@latest
 
+## OCI Images
+
+OCI images for `linux/amd64` platform are available for recent releases under https://github.com/mgumz/mtr-exporter/pkgs/container/mtr-exporter
+
 ## License
 
 see LICENSE file


### PR DESCRIPTION
Thanks for sharing this great work. This is a WIP for addressing https://github.com/mgumz/mtr-exporter/issues/15

I am experiencing flapping builds when trying this workflow
https://github.com/orange-cloudfoundry/mtr-exporter/actions/runs/11384490615 passed producing https://github.com/orange-cloudfoundry/mtr-exporter/pkgs/container/mtr-exporter/290801611?tag=0.3.0-orange

while other builds failed such as
https://github.com/orange-cloudfoundry/mtr-exporter/actions/runs/11384600069/job/31672655892

I suspect the build args and platforms might require more care