### PR TITLE
Fix -watch-jobs

### DIFF
--- a/cmd/mtr-exporter/main.go
+++ b/cmd/mtr-exporter/main.go
@@ -45,10 +45,13 @@ func main() {
 		jobs = append(jobs, j)
 	}
 
+	jobsAvailable := jobs.Empty()
+
 	if mtef.jobFile != "" {
 		if mtef.doWatchJobsFile != "" {
 			log.Printf("info: watching %q at %q", mtef.jobFile, mtef.doWatchJobsFile)
 			job.WatchJobsFile(mtef.jobFile, mtef.mtrBin, mtef.doWatchJobsFile, collector)
+			jobsAvailable = true
 		} else {
 			jobsFromFile, _, err := job.ParseJobFile(mtef.jobFile, mtef.mtrBin)
 			if err != nil {
@@ -57,11 +60,12 @@ func main() {
 			}
 			if !jobsFromFile.Empty() {
 				jobs = append(jobs, jobsFromFile...)
+				jobsAvailable = true
 			}
 		}
 	}
 
-	if jobs.Empty() {
+	if !jobsAvailable {
 		log.Println("error: no mtr jobs defined - provide at least one via -file or via arguments")
 		os.Exit(1)
 	}


### PR DESCRIPTION
When extracting jobs from a `-jobs file`, **mtr-exporter** assumes a positive amount of jobs - otherwise it exists. Zero work to do, lets go home.

The situation is slightly different when -watch-jobs is involved: It might happen, that jobs are added somewhen later. Thus, exiting too early is not correct.

This commit addresses the issue by assuming that the user might add jobs later and that already is sufficient to consider "available work".

Related: github.com/mgumz/mtr-exporter/issues/22